### PR TITLE
[noissue] Missing space in hardhat:ropsten in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "hardhat": "hardhat",
     "hardhat:kovan": "hardhat --network kovan",
     "hardhat:tenderly-main": "hardhat --network tenderlyMain",
-    "hardhat:ropsten": "hardhat--network ropsten",
+    "hardhat:ropsten": "hardhat --network ropsten",
     "hardhat:main": "hardhat --network main",
     "hardhat:docker": "hardhat --network hardhatevm_docker",
     "compile": "SKIP_LOAD=true hardhat compile",


### PR DESCRIPTION
Missing a space in the `hardhat:ropsten` command in `package.json` leading to the following error message:

```
# npm run aave:ropsten:full:migration

<snip>

> @aave/protocol-v2@1.0.1 hardhat:ropsten /src
> hardhat--network ropsten "aave:mainnet" "--verify"

sh: 1: hardhat--network: not found
```